### PR TITLE
Support for running in Google App Engine

### DIFF
--- a/src/main/java/com/plivo/helper/api/client/AppEngineClientConnection.java
+++ b/src/main/java/com/plivo/helper/api/client/AppEngineClientConnection.java
@@ -1,0 +1,328 @@
+package com.plivo.helper.api.client;
+
+/*
+ This file is based on work originally published here, under a
+ BSD 3-clause license. See the LICENSE file for more details.
+
+ https://github.com/OpenRefine/OpenRefine
+*/
+
+import org.apache.http.*;
+import org.apache.http.conn.ClientConnectionManager;
+import org.apache.http.conn.ManagedClientConnection;
+import org.apache.http.conn.routing.HttpRoute;
+import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.message.BasicHttpResponse;
+import org.apache.http.params.HttpParams;
+import org.apache.http.protocol.HttpContext;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.URL;
+import java.util.concurrent.TimeUnit;
+
+@SuppressWarnings({ "unchecked", "rawtypes" })
+class AppEngineClientConnection implements ManagedClientConnection {
+	// Managed is the composition of ConnectionReleaseTrigger,
+    //     HttpClientConnection, HttpConnection, HttpInetConnection
+
+	private ClientConnectionManager connManager;
+	private HttpRoute route;
+	private Object state;
+	private boolean reusable;
+
+	private Object request;
+	private Object response;
+	private boolean closed;
+
+	private static Object urlFS;
+
+	//GAE Classes defined via reflection
+	static Class FetchOptions;
+	static Class FetchOptionsBuilder;
+	static Class HTTPHeader;
+	static Class HTTPMethod;
+	static Class HTTPRequest;
+	static Class HTTPResponse;
+	static Class URLFetchService;
+	static Class URLFetchServiceFactory;
+
+	static {
+		//Initialize GAE classes
+		try {
+			FetchOptions = Class.forName("com.google.appengine.api.urlfetch.FetchOptions");
+			HTTPHeader = Class.forName("com.google.appengine.api.urlfetch.HTTPHeader");
+			HTTPMethod = Class.forName("com.google.appengine.api.urlfetch.HTTPMethod");
+			HTTPRequest = Class.forName("com.google.appengine.api.urlfetch.HTTPRequest");
+			HTTPResponse = Class.forName("com.google.appengine.api.urlfetch.HTTPResponse");
+			URLFetchService = Class.forName("com.google.appengine.api.urlfetch.URLFetchService");
+			URLFetchServiceFactory = Class.forName("com.google.appengine.api.urlfetch.URLFetchServiceFactory");
+			FetchOptionsBuilder = FetchOptions.getClasses()[0];
+		} catch (ClassNotFoundException e) {
+
+			e.printStackTrace();
+		}
+
+		//initialize the URL fetch service
+		try {
+			urlFS = URLFetchServiceFactory.getMethod("getURLFetchService", new Class[0]).invoke(null, new Object[0]);
+		} catch (Exception e) {
+			System.out.println("error initializing URLFetch service");
+			e.printStackTrace();
+		}
+	}
+
+	public AppEngineClientConnection(ClientConnectionManager cm, HttpRoute route,Object state) {
+		this.connManager = cm;
+		this.route = route;
+		this.state = state;
+		this.closed = true;
+	}
+
+	// ManagedClientConnection methods
+
+	public boolean isSecure() {
+		return route.isSecure();
+	}
+
+	public HttpRoute getRoute() {
+		return route;
+	}
+
+	public javax.net.ssl.SSLSession getSSLSession() {
+		return null;
+	}
+
+	public void open(HttpRoute route, HttpContext context, HttpParams params) throws IOException {
+		close();
+		this.route = route;
+	}
+
+	public void tunnelTarget(boolean secure, HttpParams params) throws IOException {
+		throw new IOException("tunnelTarget unusable");
+	}
+
+	public void tunnelProxy(HttpHost next, boolean secure, HttpParams params) throws IOException {
+		throw new IOException("tunnelProxy unusable");
+	}
+
+	public void layerProtocol(HttpContext context, HttpParams params) throws IOException {
+		throw new IOException("layerProtocol unusable");
+	}
+
+	public void markReusable() {
+		reusable = true;
+	}
+
+	public void unmarkReusable() {
+		reusable = false;
+	}
+
+	public boolean isMarkedReusable() {
+		return reusable;
+	}
+
+	public void setState(Object state) {
+		this.state = state;
+	}
+
+	public Object getState() {
+		return state;
+	}
+
+	public void setIdleDuration(long duration, TimeUnit unit) {}
+
+	public boolean isOpen() {
+		return request != null || response != null;
+	}
+
+	public boolean isStale() {
+		return !isOpen() && !closed;
+	}
+
+	public void setSocketTimeout(int timeout) {
+	}
+
+	public int getSocketTimeout() {
+		return -1;
+	}
+
+	public void shutdown() throws IOException {
+		close();
+	}
+
+	public HttpConnectionMetrics getMetrics() {
+		return null;
+	}
+
+	public InetAddress getLocalAddress() {
+		return null;
+	}
+
+	public int getLocalPort() {
+		return 0;
+	}
+
+	public InetAddress getRemoteAddress() {
+		return null;
+	}
+
+	public int getRemotePort() {
+		HttpHost host = route.getTargetHost();
+		return connManager.getSchemeRegistry().getScheme(host).resolvePort(host.getPort());
+	}
+
+	public void releaseConnection() throws IOException {
+		connManager.releaseConnection(this, Long.MAX_VALUE, TimeUnit.MILLISECONDS);
+	}
+
+	public void abortConnection() throws IOException {
+		unmarkReusable();
+		shutdown();
+	}
+
+	// HttpClientConnection methods
+
+	public void flush() throws IOException {
+		if (request != null) {
+			try {
+				Class[] parameterTypes = new Class[1];
+				parameterTypes[0] = HTTPRequest;
+
+				Method fetchMethod = URLFetchService.getMethod("fetch", parameterTypes);
+				response = fetchMethod.invoke(urlFS, request);
+				request = null;
+			} catch (Exception ex) {
+				ex.printStackTrace();
+				throw new IOException("Error flushing content in Google App Engine fetch");
+			}
+		} else {
+			response = null;
+		}
+	}
+
+	public boolean isResponseAvailable(int timeout) throws IOException {
+		return response != null;
+	}
+
+	public void close() throws IOException {
+		request = null;
+		response = null;
+		closed = true;
+	}
+
+	public void receiveResponseEntity(HttpResponse response) throws HttpException, IOException {
+		if (this.response == null) {
+			throw new IOException("receiveResponseEntity() called when closed");
+		}
+
+		ByteArrayEntity bae;
+
+		try {
+			Method getContentMethod = this.response.getClass().getMethod("getContent", new Class[0]);
+			bae = new ByteArrayEntity((byte[]) getContentMethod.invoke(this.response, new Object[0]));
+			bae.setContentType(response.getFirstHeader("Content-Type"));
+			response.setEntity(bae);
+			response = null;
+		} catch (Exception e) {
+			e.printStackTrace();
+			throw new HttpException("Error occurred while using Google App Engine URL fetch");
+		}
+	}
+
+	public HttpResponse receiveResponseHeader() throws HttpException, IOException {
+		if (this.response == null) {
+			flush();
+		}
+
+		HttpResponse response;
+
+		try {
+			Method getResponseCode = HTTPResponse.getMethod("getResponseCode", new Class[0]);
+			response = new BasicHttpResponse(new ProtocolVersion("HTTP", 1, 1), (Integer) getResponseCode.invoke(this.response, new Object[0]), null);
+
+			Method getHeaders = HTTPResponse.getMethod("getHeaders", new Class[0]);
+			for (Object h : (Iterable) getHeaders.invoke(this.response, new Object[0])) {
+				Method getName = HTTPHeader.getMethod("getName", new Class[0]);
+				Method getValue = HTTPHeader.getMethod("getValue", new Class[0]);
+				response.addHeader((String) getName.invoke(h, new Object[0]), (String) getValue.invoke(h, new Object[0]));
+			}
+		} catch (Exception e) {
+			e.printStackTrace();
+			throw new IOException("error processing response headers: "+e.getMessage(), e);
+		}
+
+		return response;
+	}
+
+	public void sendRequestHeader(HttpRequest request) throws HttpException, IOException {
+		try {
+			HttpHost host = route.getTargetHost();
+
+			URI uri = new URI(host.getSchemeName()
+					+ "://" + host.getHostName()
+					+ ((host.getPort() == -1) ? "" : (":" + host.getPort()))
+					+ request.getRequestLine().getUri());
+
+			Class[] requestConstructorTypes = new Class[3];
+			requestConstructorTypes[0] = URL.class;
+			requestConstructorTypes[1] = HTTPMethod;
+			requestConstructorTypes[2] = FetchOptions;
+
+			Constructor requestConstructor = HTTPRequest.getConstructor(requestConstructorTypes);
+
+			Class[] disallowTruncateTypes = new Class[0];
+			Method disallowTruncate = FetchOptionsBuilder.getMethod("disallowTruncate", disallowTruncateTypes);
+
+			this.request = requestConstructor.newInstance(
+				uri.toURL(),
+				Enum.valueOf(
+					(Class<? extends Enum>)Class.forName("com.google.appengine.api.urlfetch.HTTPMethod"),
+					request.getRequestLine().getMethod()
+				),
+				disallowTruncate.invoke(FetchOptionsBuilder, new Object[0])
+			);
+
+			Class[] addHeaderParameterTypes = new Class[1];
+			addHeaderParameterTypes[0] = HTTPHeader;
+			Method addHeader = HTTPRequest.getMethod("addHeader", addHeaderParameterTypes);
+
+			Class[] httpHeaderConstructorTypes = new Class[2];
+			httpHeaderConstructorTypes[0] = String.class;
+			httpHeaderConstructorTypes[1] = String.class;
+
+			Constructor httpHeaderConstructor = HTTPHeader.getConstructor(httpHeaderConstructorTypes);
+
+			for (Header h : request.getAllHeaders()) {
+				addHeader.invoke(this.request, httpHeaderConstructor.newInstance(h.getName(), h.getValue()));
+			}
+
+		} catch (Exception e) {
+			throw new IOException("Error during invocation: " + e.getMessage(), e);
+		}
+	}
+
+	@Override
+	public void sendRequestEntity(HttpEntityEnclosingRequest request) throws HttpException, IOException {
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		if (request.getEntity() != null) {
+			request.getEntity().writeTo(baos);
+		}
+
+		Class[] setPayloadParameterTypes = new Class[1];
+		setPayloadParameterTypes[0] = byte[].class;
+
+		try {
+			Method setPayload = HTTPRequest.getMethod("setPayload", setPayloadParameterTypes);
+			setPayload.invoke(this.request, baos.toByteArray());
+
+		} catch (Exception e) {
+			e.printStackTrace();
+			throw new IOException("error while sending GAE request", e);
+		}
+	}
+}

--- a/src/main/java/com/plivo/helper/api/client/AppEngineClientConnectionManager.java
+++ b/src/main/java/com/plivo/helper/api/client/AppEngineClientConnectionManager.java
@@ -1,0 +1,87 @@
+package com.plivo.helper.api.client;
+
+
+/*
+ This file is based on work originally published here, under a
+ BSD 3-clause license. See the LICENSE file for more details.
+ https://github.com/OpenRefine/OpenRefine
+*/
+
+import org.apache.http.conn.ClientConnectionManager;
+import org.apache.http.conn.ClientConnectionRequest;
+import org.apache.http.conn.ConnectTimeoutException;
+import org.apache.http.conn.ManagedClientConnection;
+import org.apache.http.conn.routing.HttpRoute;
+import org.apache.http.conn.scheme.Scheme;
+import org.apache.http.conn.scheme.SchemeRegistry;
+import org.apache.http.conn.scheme.SchemeSocketFactory;
+import org.apache.http.params.HttpParams;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.UnknownHostException;
+import java.util.concurrent.TimeUnit;
+
+public class AppEngineClientConnectionManager implements ClientConnectionManager {
+
+	private final SchemeRegistry schemes;
+
+	class NoOpSocketFactory implements SchemeSocketFactory {
+		@Override
+		public Socket connectSocket(final Socket sock, final InetSocketAddress remoteAddress,
+		                            final InetSocketAddress localAddress, final HttpParams params) throws IOException,
+		                                                                                                  UnknownHostException,
+		                                                                                                  ConnectTimeoutException {
+			return null;
+		}
+
+		@Override
+		public Socket createSocket(final HttpParams params) throws IOException {
+			return null;
+		}
+
+		@Override
+		public boolean isSecure(final Socket sock) {
+			return false;
+		}
+	}
+
+	public AppEngineClientConnectionManager() {
+		SchemeSocketFactory noOpSocketFactory = new NoOpSocketFactory();
+		schemes = new SchemeRegistry();
+		schemes.register(new Scheme("http", 80, noOpSocketFactory));
+		schemes.register(new Scheme("https", 443, noOpSocketFactory));
+	}
+
+	public void closeExpiredConnections() {
+	}
+
+	public void closeIdleConnections(final long idleTime, final TimeUnit timeUnit) {
+	}
+
+	public ManagedClientConnection getConnection(final HttpRoute route, final Object state) {
+		return new AppEngineClientConnection(this, route, state);
+	}
+
+	public SchemeRegistry getSchemeRegistry() {
+		return schemes;
+	}
+
+	public void releaseConnection(final ManagedClientConnection conn, final long valid, final TimeUnit timeUnit) {
+	}
+
+	public ClientConnectionRequest requestConnection(final HttpRoute route, final Object state) {
+		return new ClientConnectionRequest() {
+			public void abortRequest() {
+			}
+
+			public ManagedClientConnection getConnection(final long idleTime, final TimeUnit timeUnit) {
+				return AppEngineClientConnectionManager.this.getConnection(route, state);
+			}
+		};
+	}
+
+	public void shutdown() {
+	}
+}

--- a/src/main/java/com/plivo/helper/api/client/RestAPI.java
+++ b/src/main/java/com/plivo/helper/api/client/RestAPI.java
@@ -46,6 +46,8 @@ import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.message.BasicHeader;
 import org.apache.http.message.BasicHttpResponse;
 import org.apache.http.protocol.HTTP;
+import org.apache.http.conn.ClientConnectionManager;
+import org.apache.http.impl.conn.PoolingClientConnectionManager;
 
 //Add pay load to POST request 
 import org.apache.http.entity.StringEntity;
@@ -73,7 +75,19 @@ public class RestAPI {
 		AUTH_TOKEN = auth_token;
 		PLIVO_VERSION = version;
 		BaseURI = String.format("%s/%s/Account/%s", PLIVO_URL, PLIVO_VERSION, AUTH_ID);
-		Client = new DefaultHttpClient();
+
+        ClientConnectionManager clientConnectionManager;
+
+        try {
+            Class.forName("com.google.appengine.api.urlfetch.HTTPRequest");
+            clientConnectionManager = new AppEngineClientConnectionManager();
+        } catch (final ClassNotFoundException exception) {
+            clientConnectionManager = new PoolingClientConnectionManager();
+            ((PoolingClientConnectionManager) clientConnectionManager).setDefaultMaxPerRoute(10);
+        }
+
+		Client = new DefaultHttpClient(clientConnectionManager);
+
 		Client.getCredentialsProvider().setCredentials(
 				new AuthScope("api.plivo.com", 443),
 				new UsernamePasswordCredentials(AUTH_ID, AUTH_TOKEN)


### PR DESCRIPTION
HTTP calls in GAE must be done using its own infrastructure and direct calls are blocked. This adds support for running in GAE by:
- Adding **AppEngineClientConnectionManager**, a custom Apache HttpClient ConnectionManager that uses GAE's way to HTTP out;
- Changing the way **HttpClient is initialised**, by checking if we're running in GAE and if so using the custom GAE ConnectionManager.

This follows the same approach as the Java lib for _[insert major competitor here]_
