### PR TITLE
Adding gradle task to create fat jar with all dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,6 +91,17 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
   from javadoc.destinationDir
 }
 
+task fatJar(type: Jar) {
+    manifest {
+      attributes 'Implementation-Title': 'Plivo fat jar',
+      'Implementation-Version': version
+    }
+    archiveName = "plivo-java-${version}-jar-with-dependencies.jar"
+    from { configurations.compile.collect { it.isDirectory() ? it : zipTree(it) } }
+    with jar
+    print("Created fatjar: ${destinationDir}/${archiveName}")
+}
+
 task createPom << {
   pom {
     project {


### PR DESCRIPTION
 *) jar will be created with name plivo-java-${version}-jar-with-dependencies.jar
 *) full path to the jar will be logged while the task is run
 *) kick off the task from gradle by running "fatJar" task