### PR TITLE
java 9 fix for gradle javadoc task for missing javax.xml.bind issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,10 @@ if (JavaVersion.current() == JavaVersion.VERSION_1_9) {
     }
   }
 
+  javadoc {
+    options.addStringOption('-add-modules', 'java.xml.bind')
+  }
+
   test {
     doFirst {
       jvmArgs = [


### PR DESCRIPTION
This is the fix for gradle javadoc task failing for java9 with 'javax.xml.bind.annotation is not visible' error