### PR TITLE
Upgrading Retrofit/Jackson Databind to fix Issue #311

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,8 +39,8 @@ dependencies {
     
     testImplementation 'com.squareup.okhttp:mockwebserver:2.7.5'
 
-    implementation 'com.squareup.retrofit2:converter-jackson:2.2.0'
-    implementation 'com.squareup.retrofit2:retrofit:2.2.0'
+    implementation 'com.squareup.retrofit2:converter-jackson:2.12.0'
+    implementation 'com.squareup.retrofit2:retrofit:2.12.0'
     implementation 'com.squareup.okhttp3:logging-interceptor:4.12.0'
     implementation 'jakarta.xml.bind:jakarta.xml.bind-api:2.3.2'
     implementation 'org.glassfish.jaxb:jaxb-runtime:2.3.2'

--- a/pom.xml
+++ b/pom.xml
@@ -31,13 +31,13 @@
     <dependency>
       <groupId>com.squareup.retrofit2</groupId>
       <artifactId>converter-jackson</artifactId>
-      <version>2.2.0</version>
+      <version>2.12.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.squareup.retrofit2</groupId>
       <artifactId>retrofit</artifactId>
-      <version>2.2.0</version>
+      <version>2.12.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/src/main/java/com/plivo/api/PlivoClient.java
+++ b/src/main/java/com/plivo/api/PlivoClient.java
@@ -3,16 +3,7 @@ package com.plivo.api;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.BeanDescription;
-import com.fasterxml.jackson.databind.DeserializationConfig;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.deser.BeanDeserializerModifier;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
@@ -96,7 +87,7 @@ public class PlivoClient {
     objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
     objectMapper.disable(SerializationFeature.WRITE_DATE_KEYS_AS_TIMESTAMPS);
     objectMapper.setDateFormat(new SimpleDateFormat("yyyy-MM-dd HH:mm:ss"));
-    objectMapper.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
+    objectMapper.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
   }
 
   private Interceptor interceptor;


### PR DESCRIPTION
The current implementation is using a property removed in Jackson 2.20. This upgrades to the newest 2.X retrofit version to get a version of Jackson where the replacement property/Class is available and uses that. This should allow users of the library to use the newest version of Jackson 2.X without compiler issues.

Fix for: https://github.com/plivo/plivo-java/issues/311